### PR TITLE
Use an encrypted otr_keystore.ofcaes as an input.

### DIFF
--- a/keysync
+++ b/keysync
@@ -74,8 +74,18 @@ def main():
             if os.path.exists(keyfile):
                 otrapps.util.merge_keydicts(keydict, ChatSecureProperties.parse(keyfile))
             else:
-                print(('ChatSecure WARNING: No usable "' + ChatSecureProperties.keyfile +
-                    '" file found, not reading keys from ChatSecure!'))
+                encrypted_keyfile = os.path.join(args.output_folder, ChatSecureProperties.encryptedkeyfile)
+                if os.path.exists(encrypted_keyfile):
+                    if sys.version_info[0] == 2:
+                        password = raw_input("What is the encryption password for keystore \"otr_keystore.ofcaes\"?\n")
+                    else:
+                        password = input("What is the encryption password for keystore \"otr_keystore.ofcaes\"?\n")
+                    keyfile = ChatSecureProperties._decrypt_ofcaes(encrypted_keyfile, password)
+                    otrapps.util.merge_keydicts(keydict, ChatSecureProperties.parse(keyfile))
+                else:
+                    print(('ChatSecure WARNING: No usable "' + ChatSecureProperties.keyfile +
+                        '" or "' + ChatSecureProperties.encryptedkeyfile + 
+                        '" file found, not reading keys from ChatSecure!'))
             break
 
         properties = otrapps.apps[app]

--- a/otrapps/chatsecure.py
+++ b/otrapps/chatsecure.py
@@ -113,6 +113,23 @@ class ChatSecureProperties():
         ChatSecureProperties.password = password
         print((p.communicate(password)))
 
+    @staticmethod
+    def _decrypt_ofcaes(ofcaes_filename, password):
+        ''' Decrypt an encrypted key file (with user-supplied password).'''
+        # It might be a bad idea to write out this unencrypted file.
+
+        #get a tmp place to put the decrypted file
+        fd, filename = tempfile.mkstemp()
+        f = os.fdopen(fd, 'w')
+
+        #same as above, but with the -d flag to decrypt
+        cmd = ['openssl', 'aes-256-cbc', '-d', '-pass', 'stdin', '-in', ofcaes_filename,
+       '-out', filename]
+        p = subprocess.Popen(cmd, stdin=subprocess.PIPE,
+                             stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        p.communicate(password)
+        return filename
+
 
 #------------------------------------------------------------------------------#
 # for testing from the command line:


### PR DESCRIPTION
Obviously you have to still have the password.

It's worth noting that the password is requested from the user with raw_input for Python <=2.7 and input for Python > =3.0 (which are the same function, diff name). Under this function, the password is pasted into the console in the clear, not replaced with asterisks. I think this is probably okay for now, since the password is printed out via the console too, but if someone with greater Python experience knows of a better password input function, that'd probably be optimal.
