### PR TITLE
Fix forgotten settingsdir=None in gajim.py

### DIFF
--- a/otrapps/gajim.py
+++ b/otrapps/gajim.py
@@ -58,7 +58,7 @@ class GajimProperties():
         return accounts
 
     @staticmethod
-    def parse(settingsdir):
+    def parse(settingsdir=None):
         if settingsdir is None:
             settingsdir = GajimProperties.path
             accounts_config = GajimProperties.accounts_path


### PR DESCRIPTION
Causes:
Traceback (most recent call last):
  File "./keysync", line 110, in <module>
    main()
  File "./keysync", line 87, in main
    otrapps.util.merge_keydicts(keydict, properties.parse())
TypeError: parse() takes exactly 1 argument (0 given)
